### PR TITLE
if_single changes, ensure_future in async_read_loop

### DIFF
--- a/inputremapper/injection/consumer_control.py
+++ b/inputremapper/injection/consumer_control.py
@@ -21,6 +21,7 @@
 
 """Because multiple calls to async_read_loop won't work."""
 import asyncio
+import time
 import evdev
 from inputremapper.logger import logger
 from inputremapper.injection.context import Context
@@ -68,6 +69,77 @@ class ConsumerControl:
         self._forward_to = forward_to
         self.context = context
 
+    async def send_to_handlers(self, event):
+        """Send the event to callback."""
+        if event.type == evdev.ecodes.EV_MSC:
+            return False
+
+        if event.type == evdev.ecodes.EV_SYN:
+            return False
+
+        tasks = []
+        results = []
+        if (event.type, event.code) in self.context.callbacks.keys():
+            for callback in self.context.callbacks[(event.type, event.code)]:
+                # copy so that the handler doesn't screw this up for
+                # all other future handlers
+                coroutine = callback(
+                    copy_event(event),
+                    source=self._source,
+                    forward=self._forward_to,
+                )
+                tasks.append(coroutine)
+            results = await asyncio.gather(*tasks)
+
+        return True in results
+
+    async def send_to_listeners(self, event):
+        """Send the event to listeners."""
+        if event.type == evdev.ecodes.EV_MSC:
+            return False
+
+        if event.type == evdev.ecodes.EV_SYN:
+            return False
+
+        for listener in self.context.listeners.copy():
+            # use a copy, since the listeners might remove themselves form the set
+
+            # fire and forget, run them in parallel and don't wait for them, since
+            # a listener might be blocking forever while waiting for more events.
+            asyncio.ensure_future(listener(event))
+
+            # Running macros have priority, give them a head-start for processing the
+            # event.  If if_single injects a modifier, this modifier should be active
+            # before the next handler injects an "a" or something, so that it is
+            # possible to capitalize it via if_single.
+            # 1. Event from keyboard arrives (e.g. an "a")
+            # 2. the listener for if_single is called
+            # 3. if_single decides runs then (e.g. injects shift_L)
+            # 4. The original event is forwarded (or whatever it is supposed to do)
+            # 5. Capitalized "A" is injected.
+            # So make sure to call the listeners before notifying the handlers.
+            await asyncio.sleep(0)
+
+    def forward(self, event):
+        """Forward an event, which injects it unmodified."""
+        if event.type == evdev.ecodes.EV_KEY:
+            logger.debug_key((event.type, event.code, event.value), "forwarding")
+
+        self._forward_to.write(event.type, event.code, event.value)
+
+    async def handle(self, event):
+        if event.type == evdev.ecodes.EV_KEY and event.value == 2:
+            # button-hold event. Environments (gnome, etc.) create them on
+            # their own for the injection-fake-device if the release event
+            # won't appear, no need to forward or map them.
+            return
+
+        await self.send_to_listeners(event)
+
+        if not await self.send_to_handlers(event):
+            # no handler took care of it, forward it
+            self.forward(event)
+
     async def run(self):
         """Start doing things.
 
@@ -81,53 +153,7 @@ class ConsumerControl:
         )
 
         async for event in self._source.async_read_loop():
-            if event.type == evdev.ecodes.EV_KEY and event.value == 2:
-                # button-hold event. Environments (gnome, etc.) create them on
-                # their own for the injection-fake-device if the release event
-                # won't appear, no need to forward or map them.
-                continue
-
-            for listener in self.context.listeners.copy():
-                # use a copy, since the listeners might remove themselves form the set
-
-                # fire and forget, run them in parallel and don't wait for them, since
-                # a listener might be blocking forever while waiting for more events.
-                asyncio.ensure_future(listener(event))
-                
-                # Running macros have priority, give them a head-start for processing the
-                # event.  If if_single injects a modifier, this modifier should be active
-                # before the next handler injects an "a" or something, so that it is
-                # possible to capitalize it via if_single.
-                # 1. Event from keyboard arrives (e.g. an "a")
-                # 2. the listener for if_single is called
-                # 3. if_single decides runs then (e.g. injects shift_L)
-                # 4. The original event is forwarded (or whatever it is supposed to do)
-                # 5. Capitalized "A" is injected.
-                # So make sure to call the listeners before notifying the handlers.
-                await asyncio.sleep(0)
-
-            tasks = []
-            results = []
-            if (event.type, event.code) in self.context.callbacks.keys():
-                for callback in self.context.callbacks[(event.type, event.code)]:
-                    # copy so that the handler doesn't screw this up for
-                    # all other future handlers
-                    coroutine = callback(
-                        copy_event(event),
-                        source=self._source,
-                        forward=self._forward_to,
-                    )
-                    tasks.append(coroutine)
-                results = await asyncio.gather(*tasks)
-
-            if True in results:
-                continue
-
-            # forward the rest
-            if event.type == evdev.ecodes.EV_KEY:
-                logger.debug_key((event.type, event.code, event.value), "forwarding")
-            self._forward_to.write(event.type, event.code, event.value)
-            # this already includes SYN events, so need to syn here again
+            asyncio.ensure_future(self.handle(event))
 
         # This happens all the time in tests because the async_read_loop stops when
         # there is nothing to read anymore. Otherwise tests would block.

--- a/inputremapper/injection/consumer_control.py
+++ b/inputremapper/injection/consumer_control.py
@@ -117,7 +117,8 @@ class ConsumerControl:
             # 4. The original event is forwarded (or whatever it is supposed to do)
             # 5. Capitalized "A" is injected.
             # So make sure to call the listeners before notifying the handlers.
-            await asyncio.sleep(0)
+            for _ in range(5):
+                await asyncio.sleep(0)
 
     def forward(self, event):
         """Forward an event, which injects it unmodified."""
@@ -152,7 +153,7 @@ class ConsumerControl:
         )
 
         async for event in self._source.async_read_loop():
-            asyncio.ensure_future(self.handle(event))
+            await self.handle(event)
 
         # This happens all the time in tests because the async_read_loop stops when
         # there is nothing to read anymore. Otherwise tests would block.

--- a/inputremapper/injection/consumer_control.py
+++ b/inputremapper/injection/consumer_control.py
@@ -21,7 +21,6 @@
 
 """Because multiple calls to async_read_loop won't work."""
 import asyncio
-import time
 import evdev
 from inputremapper.logger import logger
 from inputremapper.injection.context import Context

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -613,6 +613,7 @@ class Macro:
                     return
 
                 if event.code != trigger_code and event.value == 1:
+                    # another key was pressed, trigger else
                     listener_done.set()
                     return
 

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -248,6 +248,8 @@ class Macro:
             logger.error('Tried to run already running macro "%s"', self.code)
             return
 
+        logger.debug('Running "%s"', self.code)
+
         self.keystroke_sleep_ms = self.context.mapping.get("macros.keystroke_sleep_ms")
 
         self.running = True
@@ -587,56 +589,59 @@ class Macro:
 
         self.tasks.append(task)
 
-    def add_if_single(self, then, otherwise, timeout=None):
+    def add_if_single(self, then, _else, timeout=None):
         """If a key was pressed without combining it."""
+        # TODO migrate "otherwise" to "else"
         _type_check(then, [Macro, None], "if_single", 1)
-        _type_check(otherwise, [Macro, None], "if_single", 2)
+        _type_check(_else, [Macro, None], "if_single", 2)
 
         if isinstance(then, Macro):
             self.child_macros.append(then)
-        if isinstance(otherwise, Macro):
-            self.child_macros.append(otherwise)
-
-        resolved_timeout = _resolve(timeout, allowed_types=[int, float, None])
+        if isinstance(_else, Macro):
+            self.child_macros.append(_else)
 
         async def task(handler):
             trigger_code = self._triggering_event.code
 
-            async def listener(event: evdev.InputEvent):
-                """receives every event from consumer_control"""
+            listener_done = asyncio.Event()
+
+            success = False
+
+            async def listener(event):
+                nonlocal success
+
                 if event.type != EV_KEY:
-                    return  # ignore anything that is not a key
+                    # ignore anything that is not a key
+                    return
+
                 if event.code != trigger_code and event.value == 1:
-                    self.context.listeners.remove(listener)
-                    await otherwise.run(handler)
+                    logger.debug("combined")
+                    listener_done.set()
+                    return
+
+                if event.code == trigger_code and event.value == 0:
+                    logger.debug("released")
+                    # the trigger was released
+                    success = True
+                    listener_done.set()
+                    return
 
             self.context.listeners.add(listener)
-            timed_out = False
-            try:
-                if resolved_timeout is not None:
-                    await asyncio.wait_for(
-                        self._trigger_release_event.wait(), resolved_timeout / 1000
-                    )
-                else:
-                    await self._trigger_release_event.wait()
 
+            try:
+                resolved_timeout = _resolve(timeout, allowed_types=[int, float, None])
+                await asyncio.wait_for(
+                    listener_done.wait(),
+                    resolved_timeout / 1000 if resolved_timeout else None,
+                )
             except asyncio.TimeoutError:
-                timed_out = True
+                pass
 
-            otherwise_has_run = False
-            try:
-                self.context.listeners.remove(listener)
-            except KeyError:
-                otherwise_has_run = True
+            self.context.listeners.remove(listener)
 
-            if timed_out and not otherwise_has_run:
-                if otherwise:
-                    await otherwise.run(handler)
-                    return
-
-            if not timed_out and not otherwise_has_run:
-                if then:
-                    await then.run(handler)
-                    return
+            if success:
+                await then.run(handler)
+            else:
+                await _else.run(handler)
 
         self.tasks.append(task)

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -613,12 +613,10 @@ class Macro:
                     return
 
                 if event.code != trigger_code and event.value == 1:
-                    logger.debug("combined")
                     listener_done.set()
                     return
 
                 if event.code == trigger_code and event.value == 0:
-                    logger.debug("released")
                     # the trigger was released
                     success = True
                     listener_done.set()


### PR DESCRIPTION
the `else` macro was not running before the forwarding.

No idea why it works now to be honest. `add_if_single` contains a few improvements. resolving the variable has to happen in the task.

I also experienced lags, but only on my keyboard. No idea. So I tried to optimize `async_read_loop` a bit. Calling listeners and callbacks is split into more functions so that there can be individual rules to avoid adding too many asyncio tasks. 

In the end, `asyncio.ensure_future(self.handle(event))` did the trick to run `else` before the forwarding. But it's somewhat a mystery to me.

I also noticed that I called the parameter of `if_single` `otherwise`, when it should be `else`... I'll add a migration at a later point for this.